### PR TITLE
Refactor the linking of images in the content collection

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -2,19 +2,19 @@
 import { z, defineCollection } from "astro:content";
 // 2. Define your collection(s)
 const postsCollection = defineCollection({
-  /* ... */
   type: "content",
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    createdAt: z.date(),
-    updatedAt: z.date(),
-    image: z.object({
-      url: z.string(),
-      alt: z.string(),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      createdAt: z.date(),
+      updatedAt: z.date(),
+      image: z.object({
+        url: image(),
+        alt: z.string(),
+      }),
+      category: z.string(),
     }),
-    category: z.string(),
-  }),
 });
 // 3. Export a single `collections` object to register your collection(s)
 //    This key should match your collection directory name in "src/content"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -9,10 +9,8 @@ const postsCollection = defineCollection({
       description: z.string(),
       createdAt: z.date(),
       updatedAt: z.date(),
-      image: z.object({
-        url: image(),
-        alt: z.string(),
-      }),
+      imageUrl: image(),
+      imageAlt: z.string(),
       category: z.string(),
     }),
 });

--- a/src/content/posts/foxlab-leaf65.mdx
+++ b/src/content/posts/foxlab-leaf65.mdx
@@ -3,9 +3,8 @@ title: "Foxlab Leaf65"
 description: "Keyboard"
 createdAt: 2024-05-23
 updatedAt: 2024-05-23
-image:
-  url: "../../assets/posts/foxlab-leaf65.jpg"
-  alt: "Foxlab Leaf65"
+imageUrl: "../../assets/posts/foxlab-leaf65.jpg"
+imageAlt: "Foxlab Leaf65"
 category: "Computing"
 slug: foxlab-leaf65
 ---

--- a/src/content/posts/foxlab-leaf65.mdx
+++ b/src/content/posts/foxlab-leaf65.mdx
@@ -4,7 +4,7 @@ description: "Keyboard"
 createdAt: 2024-05-23
 updatedAt: 2024-05-23
 image:
-  url: "/src/assets/posts/foxlab-leaf65.jpg"
+  url: "../../assets/posts/foxlab-leaf65.jpg"
   alt: "Foxlab Leaf65"
 category: "Computing"
 slug: foxlab-leaf65

--- a/src/content/posts/letshuoer-s12.mdx
+++ b/src/content/posts/letshuoer-s12.mdx
@@ -3,9 +3,8 @@ title: "Letshuoer S12 Pro"
 description: "IEM"
 createdAt: 2024-05-23
 updatedAt: 2024-05-23
-image:
-  url: "../../assets/posts/letshuoer-s12.jpg"
-  alt: "Letsuhoer S12 Pro"
+imageUrl: "../../assets/posts/letshuoer-s12.jpg"
+imageAlt: "Letsuhoer S12 Pro"
 category: "Computing"
 slug: letshuoer-s12
 ---

--- a/src/content/posts/letshuoer-s12.mdx
+++ b/src/content/posts/letshuoer-s12.mdx
@@ -4,7 +4,7 @@ description: "IEM"
 createdAt: 2024-05-23
 updatedAt: 2024-05-23
 image:
-  url: "/src/assets/posts/letshuoer-s12.jpg"
+  url: "../../assets/posts/letshuoer-s12.jpg"
   alt: "Letsuhoer S12 Pro"
 category: "Computing"
 slug: letshuoer-s12

--- a/src/content/posts/logitech-mx-master-three.mdx
+++ b/src/content/posts/logitech-mx-master-three.mdx
@@ -4,7 +4,7 @@ description: "Mouse"
 createdAt: 2024-05-19
 updatedAt: 2024-05-19
 image:
-  url: "/src/assets/posts/milad-fakurian-mx-master.jpg"
+  url: "../../assets/posts/milad-fakurian-mx-master.jpg"
   alt: "Logitech MX Master 3"
 category: "Computing"
 slug: logitech-mx-master-three

--- a/src/content/posts/logitech-mx-master-three.mdx
+++ b/src/content/posts/logitech-mx-master-three.mdx
@@ -3,9 +3,8 @@ title: "Logitech MX Master 3"
 description: "Mouse"
 createdAt: 2024-05-19
 updatedAt: 2024-05-19
-image:
-  url: "../../assets/posts/milad-fakurian-mx-master.jpg"
-  alt: "Logitech MX Master 3"
+imageUrl: "../../assets/posts/milad-fakurian-mx-master.jpg"
+imageAlt: "Logitech MX Master 3"
 category: "Computing"
 slug: logitech-mx-master-three
 ---

--- a/src/content/posts/mac-mini.mdx
+++ b/src/content/posts/mac-mini.mdx
@@ -3,9 +3,8 @@ title: "Apple Mac Mini"
 description: "Desktop computer"
 createdAt: 2024-05-18
 updatedAt: 2024-05-18
-image:
-  url: "../../assets/posts/charles-patternson-mac-mini.jpg"
-  alt: "Apple Mac Mini"
+imageUrl: "../../assets/posts/charles-patternson-mac-mini.jpg"
+imageAlt: "Apple Mac Mini"
 category: "Computing"
 slug: mac-mini
 ---

--- a/src/content/posts/mac-mini.mdx
+++ b/src/content/posts/mac-mini.mdx
@@ -4,7 +4,7 @@ description: "Desktop computer"
 createdAt: 2024-05-18
 updatedAt: 2024-05-18
 image:
-  url: "/src/assets/posts/charles-patternson-mac-mini.jpg"
+  url: "../../assets/posts/charles-patternson-mac-mini.jpg"
   alt: "Apple Mac Mini"
 category: "Computing"
 slug: mac-mini

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,17 +25,17 @@ const allPosts: CollectionEntry<'posts'>[] = (
 		<ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 			{
 				allPosts.map((post) => {
-					const { image, title, description } = post.data
+					const { imageUrl, imageAlt, title, description } = post.data
 					return (
 						<li class="text-center mb-4">
 							<a href={`/posts/${post.slug}`}>
 								<div class="w-full h-80 sm:h-48 overflow-hidden">
 									<Image 
 									class="border border-slate-300 dark:border-zinc-700 rounded-xl object-cover w-full h-full" 
-									src={image.url} 
+									src={imageUrl} 
 									width={720} 
 									height={720 / 1.777} 
-									alt={image.alt} 
+									alt={imageAlt} 
 									loading="lazy" 	
 								/>
 								</div>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -12,14 +12,14 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const {title, description, category, createdAt, updatedAt, image} = entry.data;
+const {title, description, category, createdAt, updatedAt, imageUrl, imageAlt} = entry.data;
 
 const { Content } = await entry.render();
 ---
 
 <PostLayout title={`I use ${title} - Danny Bao`}>
   <div>
-    <Image src={image.url} alt={image.alt} width={640} height={400} class="border border-slate-300 dark:border-zinc-700 rounded-xl mb-4"></Image>
+    <Image src={imageUrl} alt={imageAlt} width={640} height={400} class="border border-slate-300 dark:border-zinc-700 rounded-xl mb-4"></Image>
     <h1 class="font-lora text-xl">{title}</h1>
     <h2 class="font-lora text-lg">{description}</h2>
     <hr class="dark:border-zinc-700 my-4"></hr>

--- a/src/pages/posts/category/[...category].astro
+++ b/src/pages/posts/category/[...category].astro
@@ -39,17 +39,17 @@ const { posts } = Astro.props;
     <ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       {
         posts.map((post) => {
-          const { image, title, description } = post.data
+          const { imageUrl, imageAlt, title, description } = post.data
             return (
               <li class="text-center mb-4">
                 <a href={`/posts/${post.slug}`}>
                   <div class="w-full h-80 sm:h-48 overflow-hidden">
                     <Image 
                     class="border border-slate-300 dark:border-zinc-700 rounded-xl object-cover w-full h-full" 
-                    src={image.url} 
+                    src={imageUrl} 
                     width={720} 
                     height={720 / 1.777} 
-                    alt={image.alt} 
+                    alt={imageAlt} 
                     loading="lazy" 	
                   />
                   </div>


### PR DESCRIPTION
There was an issue with the build in production. Images would not render in production only on dev. I believe there may have been issue with the way I linked images in the front matter in the content collection. The main change is in the content schema to use the image function rather than using zod.string(). The posts have been updated to reflect this change. The build script (should) run successfully now.